### PR TITLE
Run type check and fix errors

### DIFF
--- a/src/common/core/ComponentRegistry.functional.spec.ts
+++ b/src/common/core/ComponentRegistry.functional.spec.ts
@@ -224,10 +224,10 @@ describe('ComponentRegistry Functional Tests', () => {
 
       // Track mounted routes
       const mountedRoutes: Array<{ path: string, router: Router }> = [];
-      app.use = jest.fn((path: string, router: Router) => {
+      app.use = jest.fn().mockImplementation((path: string, router: Router) => {
         mountedRoutes.push({ path, router });
         return app;
-      });
+      }) as any;
 
       registry.mountRoutes(app);
 

--- a/src/config/index.spec.ts
+++ b/src/config/index.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import config from './index';
 
 describe('Configuration Module', () => {
   let originalEnv: NodeJS.ProcessEnv;


### PR DESCRIPTION
Fix TypeScript errors in `ComponentRegistry.functional.spec.ts` and `index.spec.ts` to ensure type-check passes.

The `ComponentRegistry.functional.spec.ts` file had a type error when mocking `app.use` due to Express's method overloads, which was resolved by using `mockImplementation` and `as any`. The `index.spec.ts` file had an 'undefined' error for the `config` variable, which was fixed by adding a missing import.

---
<a href="https://cursor.com/background-agent?bcId=bc-7fd90640-993e-4f0d-b6fd-00935286e04f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7fd90640-993e-4f0d-b6fd-00935286e04f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

